### PR TITLE
chore: fix pubspec.yaml description

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: maniva_wallet
-description: "A new Flutter project."
+description: "Multi-platform Flutter wallet supporting Bitcoin (BTC/testnet3) and Rootstock (RBTC + ERC20 tokens). Single private key produces both BTC and RSK addresses for PowPeg bridge compatibility."
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: maniva_wallet
-description: "Multi-platform Flutter wallet supporting Bitcoin (BTC/testnet3) and Rootstock (RBTC + ERC20 tokens). Single private key produces both BTC and RSK addresses for PowPeg bridge compatibility."
+description: "Multi-platform Flutter wallet for Bitcoin (BTC/testnet3) and Rootstock (RBTC + ERC20). Single private key derives both BTC and RSK addresses for PowPeg compatibility."
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev


### PR DESCRIPTION
## What
Replace the default Flutter placeholder description ("A new Flutter project.") with a proper summary of the wallet: multi-platform Bitcoin (BTC/testnet3) + Rootstock (RBTC + ERC20) support with single-key dual-chain architecture for PowPeg bridge compatibility.

## Why
The pubspec.yaml description is shown in pub.dev listings, IDE tooltips, and dependency metadata. The placeholder text is unprofessional and uninformative. This change accurately describes what the package does.