### PR TITLE
ci: build and attach all 4 platforms on GitHub Release; add .deb/.rpm for Linux

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -9,6 +9,11 @@ on:
   pull_request:
     branches:
       - main
+  release:
+    types: [published]
+
+permissions:
+  contents: write
 
 jobs:
   build:
@@ -60,47 +65,36 @@ jobs:
       # Run widget tests for our flutter project.
       - run: flutter test
 
-      # Build apk.
-      - run: flutter build apk
+      # Build apk. RELEASE_NAME (shown in Settings > About) is only
+      # non-empty when this run was triggered by an actual published GitHub
+      # Release - passed via env, not interpolated directly into the shell
+      # command, since github.event.release.name is untrusted user input.
+      - name: Build apk
+        env:
+          RELEASE_NAME: ${{ github.event.release.name }}
+        run: flutter build apk --dart-define=RELEASE_NAME="$RELEASE_NAME"
 
-      # Upload generated apk to the artifacts. Gradle's actual output
-      # filename is app-release.apk (not maniva-release.apk - there's no
-      # archivesBaseName override anywhere that would rename it).
+      # Gradle's actual output filename is app-release.apk (not
+      # maniva-release.apk - there's no archivesBaseName override anywhere
+      # that would rename it). Copy it under a stable, descriptive name
+      # shared by the artifact upload and the release-asset upload below.
+      - name: Archive APK
+        run: |
+          mkdir -p build/artifacts
+          cp build/app/outputs/apk/release/app-release.apk build/artifacts/${{ github.run_number }}-maniva-android.apk
+
       - uses: actions/upload-artifact@v4
         with:
           name: apk
-          path: build/app/outputs/apk/release/app-release.apk
+          path: build/artifacts/${{ github.run_number }}-maniva-android.apk
 
-  release:
-    name: Release APK
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download APK from build
-        uses: actions/download-artifact@v4
+      # Only on an actual GitHub Release being published (not on every push/
+      # PR) - attaches the APK as a release asset. Replaces the old
+      # always-on `release` job, which created a *new* GitHub Release
+      # tagged by run number on every push/PR to main, unrelated to any
+      # release the user actually created.
+      - name: Upload APK to GitHub Release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
         with:
-          name: apk
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.run_number }}
-          release_name: ${{ github.event.repository.name }} v${{ github.run_number }}
-      - name: Upload Release APK
-        id: upload_release_asset
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # download-artifact restores the file under its uploaded basename
-          # (app-release.apk, matching the build job's upload path above),
-          # not the run-number-suffixed name this previously assumed - that
-          # file never existed, so this step always failed. asset_name is
-          # just the display name in the Release and can still include the
-          # run number.
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./app-release.apk
-          asset_name: maniva-release-${{ github.run_number }}.apk
-          asset_content_type: application/vnd.android.package-archive
+          files: build/artifacts/${{ github.run_number }}-maniva-android.apk

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
   workflow_dispatch: {}
+  release:
+    types: [published]
+
+permissions:
+  contents: write
 
 jobs:
   build-linux:
@@ -27,7 +32,16 @@ jobs:
           # libcurl4-openssl-dev: sentry_flutter's Linux native build (sentry-native,
           # vendored via CMake FetchContent) requires libcurl's dev headers -
           # without it, CMake configure fails with "Could NOT find CURL".
-          sudo apt-get install -y libgtk-3-dev clang cmake libgl1-mesa-dev libglu1-mesa-dev libcurl4-openssl-dev
+          # ruby/rubygems: needed to install fpm, which packages the .deb/.rpm below.
+          sudo apt-get install -y libgtk-3-dev clang cmake libgl1-mesa-dev libglu1-mesa-dev libcurl4-openssl-dev ruby ruby-dev rubygems build-essential rpm
+
+      - name: Install fpm
+        # fpm ("effing package management") packages a plain directory into
+        # .deb and .rpm from the same input - no separate Ubuntu/RHEL build
+        # environment needed, since the Flutter Linux bundle itself is the
+        # same binary either way (it only depends on GTK3/glib, present on
+        # both).
+        run: sudo gem install --no-document fpm
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
@@ -56,8 +70,14 @@ jobs:
 
       - run: flutter analyze --no-fatal-infos --no-fatal-warnings .
       - run: flutter test
+      # RELEASE_NAME (shown in Settings > About) is only non-empty when this
+      # run was triggered by an actual published GitHub Release - passed via
+      # env, not interpolated directly into the shell command, since
+      # github.event.release.name is untrusted user input.
       - name: Build Linux app (release)
-        run: flutter build linux --release
+        env:
+          RELEASE_NAME: ${{ github.event.release.name }}
+        run: flutter build linux --release --dart-define=RELEASE_NAME="$RELEASE_NAME"
 
       - name: Show build output (debug)
         run: ls -la build/linux/x64/release/bundle || true
@@ -79,3 +99,77 @@ jobs:
         with:
           name: linux-bundle
           path: build/artifacts/${{ github.run_number }}-maniva-app.tar.gz
+
+      # Same Flutter Linux bundle, wrapped as .deb (Ubuntu/Debian) and .rpm
+      # (RHEL/Fedora) with fpm from one shared staging directory - the
+      # bundle only depends on GTK3/glib, present on both families, so no
+      # separate per-distro build is needed. Installs to /opt (side-by-side
+      # with other vendor apps) with a /usr/bin launcher and a desktop
+      # entry, matching normal Linux packaging conventions.
+      - name: Package .deb and .rpm
+        run: |
+          set -e
+          VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: *//' | cut -d'+' -f1)
+          BUNDLE_DIR="build/linux/x64/release/bundle"
+          PKG_ROOT="build/pkgroot"
+          APP_DIR="$PKG_ROOT/opt/maniva-wallet"
+
+          mkdir -p "$APP_DIR" "$PKG_ROOT/usr/bin" "$PKG_ROOT/usr/share/applications" \
+            "$PKG_ROOT/usr/share/icons/hicolor/256x256/apps"
+          cp -r "$BUNDLE_DIR"/. "$APP_DIR/"
+
+          cat > "$PKG_ROOT/usr/bin/maniva-wallet" <<'EOF'
+          #!/bin/sh
+          exec /opt/maniva-wallet/my_rootstock_wallet "$@"
+          EOF
+          chmod +x "$PKG_ROOT/usr/bin/maniva-wallet"
+
+          cp assets/images/maniva_logo.png \
+            "$PKG_ROOT/usr/share/icons/hicolor/256x256/apps/maniva-wallet.png"
+
+          cat > "$PKG_ROOT/usr/share/applications/maniva-wallet.desktop" <<EOF
+          [Desktop Entry]
+          Type=Application
+          Name=Maniva Wallet
+          Comment=Bitcoin and Rootstock wallet
+          Exec=/usr/bin/maniva-wallet
+          Icon=maniva-wallet
+          Categories=Finance;
+          Terminal=false
+          EOF
+
+          mkdir -p build/artifacts
+          fpm -s dir -t deb -n maniva-wallet -v "$VERSION" \
+            --description "Bitcoin and Rootstock wallet" \
+            --license "See repository" \
+            -p "build/artifacts/${{ github.run_number }}-maniva-wallet.deb" \
+            -C "$PKG_ROOT" usr opt
+
+          fpm -s dir -t rpm -n maniva-wallet -v "$VERSION" \
+            --description "Bitcoin and Rootstock wallet" \
+            --license "See repository" \
+            -p "build/artifacts/${{ github.run_number }}-maniva-wallet.rpm" \
+            -C "$PKG_ROOT" usr opt
+
+      - name: Upload .deb artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-deb
+          path: build/artifacts/${{ github.run_number }}-maniva-wallet.deb
+
+      - name: Upload .rpm artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-rpm
+          path: build/artifacts/${{ github.run_number }}-maniva-wallet.rpm
+
+      # Only on an actual GitHub Release being published (not on every push
+      # or manual dispatch) - attaches all 3 Linux packaging formats.
+      - name: Upload Linux builds to GitHub Release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            build/artifacts/${{ github.run_number }}-maniva-app.tar.gz
+            build/artifacts/${{ github.run_number }}-maniva-wallet.deb
+            build/artifacts/${{ github.run_number }}-maniva-wallet.rpm

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,6 +9,11 @@ on:
     branches:
       - main
   workflow_dispatch: {}
+  release:
+    types: [published]
+
+permissions:
+  contents: write
 
 jobs:
   build-macos:
@@ -58,8 +63,14 @@ jobs:
       - run: flutter analyze --no-fatal-infos --no-fatal-warnings .
       - run: flutter test
 
-      - name: Build macOS app (debug)
-        run: flutter build macos --release
+      # RELEASE_NAME (shown in Settings > About) is only non-empty when this
+      # run was triggered by an actual published GitHub Release - passed via
+      # env, not interpolated directly into the shell command, since
+      # github.event.release.name is untrusted user input.
+      - name: Build macOS app (release)
+        env:
+          RELEASE_NAME: ${{ github.event.release.name }}
+        run: flutter build macos --release --dart-define=RELEASE_NAME="$RELEASE_NAME"
 
       - name: Update macOs artifact path
         uses: actions/upload-artifact@v4
@@ -87,3 +98,11 @@ jobs:
         with:
           name: macos-runner
           path: build/artifacts/${{ github.run_number }}-maniva_wallet.zip
+
+      # Only on an actual GitHub Release being published (not on every push/
+      # PR/manual dispatch) - attaches the zipped app as a release asset.
+      - name: Upload macOS build to GitHub Release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: build/artifacts/${{ github.run_number }}-maniva_wallet.zip

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
   workflow_dispatch: {}
+  release:
+    types: [published]
+
+permissions:
+  contents: write
 
 jobs:
   build-web:
@@ -49,8 +54,14 @@ jobs:
       - run: flutter analyze --no-fatal-infos --no-fatal-warnings .
       - run: flutter test
 
+      # RELEASE_NAME (shown in Settings > About) is only non-empty when this
+      # run was triggered by an actual published GitHub Release - passed via
+      # env, not interpolated directly into the shell command, since
+      # github.event.release.name is untrusted user input.
       - name: Build web (release)
-        run: flutter build web --release
+        env:
+          RELEASE_NAME: ${{ github.event.release.name }}
+        run: flutter build web --release --dart-define=RELEASE_NAME="$RELEASE_NAME"
 
       - name: Show build output (debug)
         run: ls -la build/web || true
@@ -72,3 +83,11 @@ jobs:
         with:
           name: web-bundle
           path: build/artifacts/${{ github.run_number }}-maniva-web-app.tar.gz
+
+      # Only on an actual GitHub Release being published (not on every push
+      # or manual dispatch) - attaches the web bundle as a release asset.
+      - name: Upload web build to GitHub Release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: build/artifacts/${{ github.run_number }}-maniva-web-app.tar.gz

--- a/lib/pages/menu/settings_page.dart
+++ b/lib/pages/menu/settings_page.dart
@@ -21,6 +21,12 @@ class SettingsPage extends StatefulWidget {
 class _SettingsPageState extends State<SettingsPage> {
   String _appVersion = '';
 
+  // Set at build time via --dart-define=RELEASE_NAME=... by the CI workflows
+  // (only when triggered by an actual published GitHub Release, from
+  // github.event.release.name) - empty for regular push/PR/dispatch builds,
+  // in which case it's simply not shown.
+  static const String _releaseName = String.fromEnvironment('RELEASE_NAME', defaultValue: '');
+
   final _bitcoinNodeController = TextEditingController();
   final _bitcoinEsploraController = TextEditingController();
   final _rootstockNodeController = TextEditingController();
@@ -40,7 +46,8 @@ class _SettingsPageState extends State<SettingsPage> {
     PackageInfo.fromPlatform().then((info) {
       if (mounted) {
         setState(() {
-          _appVersion = 'v${info.version}';
+          final suffix = _releaseName.isNotEmpty ? ' ($_releaseName)' : '';
+          _appVersion = 'v${info.version}$suffix';
         });
       }
     });
@@ -79,8 +86,7 @@ class _SettingsPageState extends State<SettingsPage> {
     return uri != null && (uri.scheme == 'http' || uri.scheme == 'https') && uri.host.isNotEmpty;
   }
 
-  Future<void> _saveNodeUrl(
-      String key, String value, WalletServiceImpl walletService) async {
+  Future<void> _saveNodeUrl(String key, String value, WalletServiceImpl walletService) async {
     if (!_isValidUrlOrEmpty(value)) {
       showMessage(AppLocalizations.of(context)!.invalidUrlMessage, context);
       return;
@@ -233,9 +239,7 @@ class _SettingsPageState extends State<SettingsPage> {
               ),
             ),
             const SizedBox(height: 16),
-            Text(
-                t.customNodeUrlsLabel(
-                    walletService.isMainnet ? t.mainnetLabel : t.testnetLabel),
+            Text(t.customNodeUrlsLabel(walletService.isMainnet ? t.mainnetLabel : t.testnetLabel),
                 style: const TextStyle(
                     color: rootstockCream, fontSize: 18, fontWeight: FontWeight.bold)),
             const SizedBox(height: 4),


### PR DESCRIPTION
## Summary
When you publish a GitHub Release, all 4 platform workflows now build and attach their artifact to it automatically. Also adds `.deb`/`.rpm` packaging for Linux, and surfaces the release name in the app itself.

- Added `release: types: [published]` as a trigger to `android.yml`, `macos.yml`, `linux.yml`, `web.yml` (existing push/PR/dispatch triggers are untouched — this is additive).
- Each workflow gets a final step, gated on `if: github.event_name == 'release'`, that uploads its build to the release via `softprops/action-gh-release`:
  - **Android**: `app-release.apk`
  - **macOS**: the zipped `.app` bundle
  - **Web**: the tar.gz'd `build/web`
  - **Linux**: the existing tar.gz bundle, **plus new `.deb` and `.rpm` packages** built with `fpm` from one shared staging directory (installs to `/opt/maniva-wallet`, with a `/usr/bin/maniva-wallet` launcher, desktop entry, and app icon). Same underlying Flutter bundle works for both Ubuntu and RHEL/Fedora — it only needs GTK3/glib, present on both.
- **Removed** `android.yml`'s old always-on `release` job, which created a *new* GitHub Release (tagged by run number) on **every** push/PR — that behavior conflicts with the new model where you create the release yourself and CI just attaches artifacts to it.
- Bonus: the app's **Settings → About** screen now shows the release name alongside the version, via a `RELEASE_NAME` dart-define the workflows pass at build time (empty/hidden for regular push/PR/dispatch builds — only populated when triggered by a real published release). Passed through `env:`, not interpolated directly into the shell command, since the release name is untrusted input.

## Verification
- All 4 workflow YAML files validated (`ruby -ryaml`).
- `flutter analyze` — 0 errors/warnings.
- `flutter test` — 104 passed, 1 skipped.
- `flutter build macos --debug --dart-define=RELEASE_NAME="..."` — succeeds; app launches.
- Linux `.deb`/`.rpm` packaging logic tested locally end-to-end (macOS + Homebrew `rpm`/`dpkg`/`fpm`) against a synthetic bundle mimicking the real Flutter output: staging layout, file permissions, desktop entry, and icon all verified correct via `rpm -qlvp`. The `.rpm` itself built and inspected successfully. The `.deb` build failed locally only because macOS's BSD `ar` isn't compatible with fpm's Debian packer (needs the real Ubuntu runner's GNU `ar`/`dpkg-deb`) — same "no local Linux host" constraint as the rest of this project's Linux CI work; needs confirmation on a real run.

## Test plan
- [ ] Publish a test GitHub Release against this branch (or dispatch manually is not possible for `release`-triggered steps — needs an actual release) to confirm all 4 artifacts attach correctly, and that the `.deb`/`.rpm` build for real on the Ubuntu runner.
- [ ] Install the `.deb` on an Ubuntu box and the `.rpm` on a Fedora/RHEL box to confirm both launch via the desktop entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)